### PR TITLE
Add additional @Controller with e2e scenarios defined for easier exploration.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,11 @@
 			<artifactId>springfox-swagger-ui</artifactId>
 			<version>2.9.2</version>
 		</dependency>
+		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-lang3</artifactId>
+			<version>3.11</version>
+		</dependency>
 
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/src/main/java/pro/idugalic/axonstatemachine/command/api/OrderItem.java
+++ b/src/main/java/pro/idugalic/axonstatemachine/command/api/OrderItem.java
@@ -1,11 +1,6 @@
 package pro.idugalic.axonstatemachine.command.api;
 
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.math.BigDecimal;
 
@@ -13,6 +8,7 @@ import java.math.BigDecimal;
 @AllArgsConstructor
 @Builder
 @Getter
+@ToString
 @EqualsAndHashCode
 public class OrderItem {
 

--- a/src/main/java/pro/idugalic/axonstatemachine/command/api/command/CreateOrderCommand.java
+++ b/src/main/java/pro/idugalic/axonstatemachine/command/api/command/CreateOrderCommand.java
@@ -1,9 +1,6 @@
 package pro.idugalic.axonstatemachine.command.api.command;
 
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import org.axonframework.modelling.command.TargetAggregateIdentifier;
 import pro.idugalic.axonstatemachine.command.api.OrderItem;
 
@@ -11,6 +8,7 @@ import java.util.ArrayList;
 import java.util.UUID;
 
 @Getter
+@ToString
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 final public class CreateOrderCommand {

--- a/src/main/java/pro/idugalic/axonstatemachine/command/api/command/MarkOrderAsCancelledCommand.java
+++ b/src/main/java/pro/idugalic/axonstatemachine/command/api/command/MarkOrderAsCancelledCommand.java
@@ -1,12 +1,10 @@
 package pro.idugalic.axonstatemachine.command.api.command;
 
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import org.axonframework.modelling.command.TargetAggregateIdentifier;
 
 @Getter
+@ToString
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 final public class MarkOrderAsCancelledCommand {

--- a/src/main/java/pro/idugalic/axonstatemachine/command/api/command/MarkOrderAsDeliveredCommand.java
+++ b/src/main/java/pro/idugalic/axonstatemachine/command/api/command/MarkOrderAsDeliveredCommand.java
@@ -1,12 +1,10 @@
 package pro.idugalic.axonstatemachine.command.api.command;
 
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import org.axonframework.modelling.command.TargetAggregateIdentifier;
 
 @Getter
+@ToString
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 final public class MarkOrderAsDeliveredCommand {

--- a/src/main/java/pro/idugalic/axonstatemachine/command/api/command/MarkOrderAsPaidCommand.java
+++ b/src/main/java/pro/idugalic/axonstatemachine/command/api/command/MarkOrderAsPaidCommand.java
@@ -1,12 +1,10 @@
 package pro.idugalic.axonstatemachine.command.api.command;
 
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import org.axonframework.modelling.command.TargetAggregateIdentifier;
 
 @Getter
+@ToString
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 final public class MarkOrderAsPaidCommand {

--- a/src/main/java/pro/idugalic/axonstatemachine/command/api/event/AbstractOrderCreatedEvent.java
+++ b/src/main/java/pro/idugalic/axonstatemachine/command/api/event/AbstractOrderCreatedEvent.java
@@ -1,15 +1,13 @@
 package pro.idugalic.axonstatemachine.command.api.event;
 
-import lombok.AccessLevel;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import pro.idugalic.axonstatemachine.command.api.OrderItem;
 import pro.idugalic.axonstatemachine.command.api.OrderStatus;
 
 import java.util.ArrayList;
 
 @Getter
+@ToString(callSuper = true)
 @NoArgsConstructor(access = AccessLevel.PACKAGE)
 @EqualsAndHashCode(callSuper = true)
 public abstract class AbstractOrderCreatedEvent extends AbstractOrderEvent {

--- a/src/main/java/pro/idugalic/axonstatemachine/command/api/event/AbstractOrderDeletedEvent.java
+++ b/src/main/java/pro/idugalic/axonstatemachine/command/api/event/AbstractOrderDeletedEvent.java
@@ -1,11 +1,9 @@
 package pro.idugalic.axonstatemachine.command.api.event;
 
-import lombok.AccessLevel;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Getter
+@ToString(callSuper = true)
 @NoArgsConstructor(access = AccessLevel.PACKAGE)
 @EqualsAndHashCode(callSuper = true)
 public abstract class AbstractOrderDeletedEvent extends AbstractOrderEvent {

--- a/src/main/java/pro/idugalic/axonstatemachine/command/api/event/AbstractOrderEvent.java
+++ b/src/main/java/pro/idugalic/axonstatemachine/command/api/event/AbstractOrderEvent.java
@@ -1,12 +1,9 @@
 package pro.idugalic.axonstatemachine.command.api.event;
 
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Getter
+@ToString
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PACKAGE)
 @EqualsAndHashCode(exclude = "aggregateIdentifier")

--- a/src/main/java/pro/idugalic/axonstatemachine/command/api/event/ItemAddedEvent.java
+++ b/src/main/java/pro/idugalic/axonstatemachine/command/api/event/ItemAddedEvent.java
@@ -1,12 +1,10 @@
 package pro.idugalic.axonstatemachine.command.api.event;
 
-import lombok.AccessLevel;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import pro.idugalic.axonstatemachine.command.api.OrderItem;
 
 @Getter
+@ToString(callSuper = true)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @EqualsAndHashCode(callSuper = true)
 final public class ItemAddedEvent extends AbstractOrderEvent{

--- a/src/main/java/pro/idugalic/axonstatemachine/command/api/event/OrderCanceledEvent.java
+++ b/src/main/java/pro/idugalic/axonstatemachine/command/api/event/OrderCanceledEvent.java
@@ -1,15 +1,13 @@
 package pro.idugalic.axonstatemachine.command.api.event;
 
-import lombok.AccessLevel;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import pro.idugalic.axonstatemachine.command.api.OrderItem;
 import pro.idugalic.axonstatemachine.command.api.OrderStatus;
 
 import java.util.ArrayList;
 
 @Getter
+@ToString(callSuper = true)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @EqualsAndHashCode(callSuper = true)
 final public class OrderCanceledEvent extends AbstractOrderCreatedEvent {

--- a/src/main/java/pro/idugalic/axonstatemachine/command/api/event/OrderCancellationInitiatedEvent.java
+++ b/src/main/java/pro/idugalic/axonstatemachine/command/api/event/OrderCancellationInitiatedEvent.java
@@ -1,11 +1,9 @@
 package pro.idugalic.axonstatemachine.command.api.event;
 
-import lombok.AccessLevel;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Getter
+@ToString(callSuper = true)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @EqualsAndHashCode(callSuper = true)
 final public class OrderCancellationInitiatedEvent extends AbstractOrderDeletedEvent {

--- a/src/main/java/pro/idugalic/axonstatemachine/command/api/event/OrderCreatedEvent.java
+++ b/src/main/java/pro/idugalic/axonstatemachine/command/api/event/OrderCreatedEvent.java
@@ -1,15 +1,13 @@
 package pro.idugalic.axonstatemachine.command.api.event;
 
-import lombok.AccessLevel;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import pro.idugalic.axonstatemachine.command.api.OrderItem;
 import pro.idugalic.axonstatemachine.command.api.OrderStatus;
 
 import java.util.ArrayList;
 
 @Getter
+@ToString(callSuper = true)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @EqualsAndHashCode(callSuper = true)
 final public class OrderCreatedEvent extends AbstractOrderCreatedEvent {

--- a/src/main/java/pro/idugalic/axonstatemachine/command/api/event/OrderDeliveredEvent.java
+++ b/src/main/java/pro/idugalic/axonstatemachine/command/api/event/OrderDeliveredEvent.java
@@ -1,15 +1,13 @@
 package pro.idugalic.axonstatemachine.command.api.event;
 
-import lombok.AccessLevel;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import pro.idugalic.axonstatemachine.command.api.OrderItem;
 import pro.idugalic.axonstatemachine.command.api.OrderStatus;
 
 import java.util.ArrayList;
 
 @Getter
+@ToString(callSuper = true)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @EqualsAndHashCode(callSuper = true)
 final public class OrderDeliveredEvent extends AbstractOrderCreatedEvent {

--- a/src/main/java/pro/idugalic/axonstatemachine/command/api/event/OrderDeliveryInitiatedEvent.java
+++ b/src/main/java/pro/idugalic/axonstatemachine/command/api/event/OrderDeliveryInitiatedEvent.java
@@ -1,11 +1,9 @@
 package pro.idugalic.axonstatemachine.command.api.event;
 
-import lombok.AccessLevel;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Getter
+@ToString(callSuper = true)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @EqualsAndHashCode(callSuper = true)
 final public class OrderDeliveryInitiatedEvent extends AbstractOrderDeletedEvent {

--- a/src/main/java/pro/idugalic/axonstatemachine/command/api/event/OrderPaidEvent.java
+++ b/src/main/java/pro/idugalic/axonstatemachine/command/api/event/OrderPaidEvent.java
@@ -1,15 +1,13 @@
 package pro.idugalic.axonstatemachine.command.api.event;
 
-import lombok.AccessLevel;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import pro.idugalic.axonstatemachine.command.api.OrderItem;
 import pro.idugalic.axonstatemachine.command.api.OrderStatus;
 
 import java.util.ArrayList;
 
 @Getter
+@ToString(callSuper = true)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @EqualsAndHashCode(callSuper = true)
 final public class OrderPaidEvent extends AbstractOrderCreatedEvent {

--- a/src/main/java/pro/idugalic/axonstatemachine/command/api/event/OrderPayingInitiatedEvent.java
+++ b/src/main/java/pro/idugalic/axonstatemachine/command/api/event/OrderPayingInitiatedEvent.java
@@ -1,11 +1,9 @@
 package pro.idugalic.axonstatemachine.command.api.event;
 
-import lombok.AccessLevel;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Getter
+@ToString(callSuper = true)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @EqualsAndHashCode(callSuper = true)
 final public class OrderPayingInitiatedEvent extends AbstractOrderDeletedEvent {

--- a/src/main/java/pro/idugalic/axonstatemachine/command/api/event/UnsupportedOperationEvent.java
+++ b/src/main/java/pro/idugalic/axonstatemachine/command/api/event/UnsupportedOperationEvent.java
@@ -1,11 +1,9 @@
 package pro.idugalic.axonstatemachine.command.api.event;
 
-import lombok.AccessLevel;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Getter
+@ToString(callSuper = true)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @EqualsAndHashCode(callSuper = true)
 final public class UnsupportedOperationEvent extends AbstractOrderEvent{

--- a/src/main/java/pro/idugalic/axonstatemachine/query/OrderStateTransitionsProjection.java
+++ b/src/main/java/pro/idugalic/axonstatemachine/query/OrderStateTransitionsProjection.java
@@ -1,0 +1,94 @@
+package pro.idugalic.axonstatemachine.query;
+
+import org.axonframework.eventhandling.EventHandler;
+import org.axonframework.queryhandling.QueryHandler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import pro.idugalic.axonstatemachine.command.api.OrderStatus;
+import pro.idugalic.axonstatemachine.command.api.event.OrderCanceledEvent;
+import pro.idugalic.axonstatemachine.command.api.event.OrderCreatedEvent;
+import pro.idugalic.axonstatemachine.command.api.event.OrderDeliveredEvent;
+import pro.idugalic.axonstatemachine.command.api.event.OrderPaidEvent;
+import pro.idugalic.axonstatemachine.query.api.GetAllStateTransitionAggregateIdsRequest;
+import pro.idugalic.axonstatemachine.query.api.GetAllStateTransitionAggregateIdsResponse;
+
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Component
+public class OrderStateTransitionsProjection {
+    private static final Logger log = LoggerFactory.getLogger(OrderStateTransitionsProjection.class);
+
+    /**
+     * The purpose of the map is to contain a reference of all state transitions of
+     * an order. The "orderId" field remains constant between all state transitions
+     * but the aggregateId keeps changing.
+     *
+     * So we keep a map from an order ID to a map containing the aggregate
+     * ID of each constituent state in the finite state machine.
+     *
+     * E.G.
+     *   orderId =  1    retrieves a map of (for example):  NULL -> "uuid"
+     *                                                      NEW  -> "uuid"
+     *                                                      ... ->
+     */
+    private final ConcurrentHashMap<String, ConcurrentHashMap<OrderStatus, UUID>> orderStateTransitionsMap
+            = new ConcurrentHashMap<>();
+
+    @EventHandler
+    void on (OrderCreatedEvent evt) {
+        log.info("Handling event: {}", evt);
+
+        // Create the inner map which will track all state transitions for this particular order id.
+        ConcurrentHashMap<OrderStatus, UUID> innerMap = new ConcurrentHashMap<>();
+        innerMap.put(OrderStatus.NEW, UUID.fromString(evt.getAggregateIdentifier()));
+
+        // Place the inner map as the value for the order id (which remains constant across all state transitions).
+        String orderId = evt.getOrderId();
+        orderStateTransitionsMap.put(orderId, innerMap);
+    }
+
+    @EventHandler
+    void on(OrderCanceledEvent evt) {
+        log.info("Handling event: {}", evt);
+
+        // Retrieve the existing inner map entry (or throw NPE if it does not exist).
+        ConcurrentHashMap<OrderStatus, UUID> innerMap = orderStateTransitionsMap.get(evt.getOrderId());
+
+        // Update the inner map with the aggregate ID with the newly created state.
+        innerMap.put(OrderStatus.CANCELED, UUID.fromString(evt.getAggregateIdentifier()));
+    }
+
+    @EventHandler
+    void on(OrderPaidEvent evt) {
+        log.info("Handling event: {}", evt);
+
+        // Retrieve the existing inner map entry (or throw NPE if it does not exist).
+        ConcurrentHashMap<OrderStatus, UUID> innerMap = orderStateTransitionsMap.get(evt.getOrderId());
+
+        // Update the inner map with the aggregate ID with the newly created state.
+        innerMap.put(OrderStatus.PAID, UUID.fromString(evt.getAggregateIdentifier()));
+    }
+
+    @EventHandler
+    void on(OrderDeliveredEvent evt) {
+        log.info("Handling event: {}", evt);
+
+        // Retrieve the existing inner map entry (or throw NPE if it does not exist).
+        ConcurrentHashMap<OrderStatus, UUID> innerMap = orderStateTransitionsMap.get(evt.getOrderId());
+
+        // Update the inner map with the aggregate ID with the newly created state.
+        innerMap.put(OrderStatus.DELIVERED, UUID.fromString(evt.getAggregateIdentifier()));
+    }
+
+
+    /**
+     * Retrieve all aggregate IDs for the associated states for the orderId specified in the query.
+     */
+    @QueryHandler
+    public GetAllStateTransitionAggregateIdsResponse on(GetAllStateTransitionAggregateIdsRequest query) {
+        ConcurrentHashMap<OrderStatus, UUID> innerMap = orderStateTransitionsMap.get(query.getOrderId());
+        return new GetAllStateTransitionAggregateIdsResponse(query.getOrderId(), innerMap);
+    }
+}

--- a/src/main/java/pro/idugalic/axonstatemachine/query/api/GetAllStateTransitionAggregateIdsRequest.java
+++ b/src/main/java/pro/idugalic/axonstatemachine/query/api/GetAllStateTransitionAggregateIdsRequest.java
@@ -1,0 +1,13 @@
+package pro.idugalic.axonstatemachine.query.api;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class GetAllStateTransitionAggregateIdsRequest {
+    private String orderId;
+}

--- a/src/main/java/pro/idugalic/axonstatemachine/query/api/GetAllStateTransitionAggregateIdsResponse.java
+++ b/src/main/java/pro/idugalic/axonstatemachine/query/api/GetAllStateTransitionAggregateIdsResponse.java
@@ -1,0 +1,16 @@
+package pro.idugalic.axonstatemachine.query.api;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import pro.idugalic.axonstatemachine.command.api.OrderStatus;
+
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Data
+@AllArgsConstructor
+public class GetAllStateTransitionAggregateIdsResponse {
+
+    private String orderId;
+    private ConcurrentHashMap<OrderStatus, UUID> stateToAggregateId;
+}

--- a/src/main/java/pro/idugalic/axonstatemachine/web/QuickScenarioDemoRestController.java
+++ b/src/main/java/pro/idugalic/axonstatemachine/web/QuickScenarioDemoRestController.java
@@ -1,0 +1,226 @@
+package pro.idugalic.axonstatemachine.web;
+
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.commons.lang3.RandomUtils;
+import org.axonframework.commandhandling.gateway.CommandGateway;
+import org.axonframework.messaging.responsetypes.ResponseTypes;
+import org.axonframework.queryhandling.QueryGateway;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import pro.idugalic.axonstatemachine.command.api.OrderItem;
+import pro.idugalic.axonstatemachine.command.api.OrderStatus;
+import pro.idugalic.axonstatemachine.command.api.command.CreateOrderCommand;
+import pro.idugalic.axonstatemachine.command.api.command.MarkOrderAsCancelledCommand;
+import pro.idugalic.axonstatemachine.command.api.command.MarkOrderAsDeliveredCommand;
+import pro.idugalic.axonstatemachine.command.api.command.MarkOrderAsPaidCommand;
+import pro.idugalic.axonstatemachine.query.api.GetAllStateTransitionAggregateIdsRequest;
+import pro.idugalic.axonstatemachine.query.api.GetAllStateTransitionAggregateIdsResponse;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+/**
+ * Exposes a number of different endpoints which run end-to-end scenarios.
+ *
+ * The purpose is for you to then interactively explore the Axon server event store
+ * to understand what events have been logged.
+ *
+ * Where possible we log as much as possible in order to see what is happening in the system.
+ */
+@CrossOrigin("*")
+@RestController
+@RequestMapping(value = "/api/quick-demo")
+public class QuickScenarioDemoRestController {
+    private static final Logger log = LoggerFactory.getLogger(QuickScenarioDemoRestController.class);
+
+    /**
+     * Threadsafe long generator used to create IDs when needed.
+     */
+    private final AtomicLong idGenerator;
+
+    /**
+     * Used to issue commands.
+     */
+    private final CommandGateway commandGateway;
+
+    /**
+     * Query gateway we will issue queries to.
+     */
+    private final QueryGateway queryGateway;
+
+    public QuickScenarioDemoRestController(
+            CommandGateway commandGateway,
+            QueryGateway queryGateway) {
+        this.idGenerator = new AtomicLong();
+        this.commandGateway = commandGateway;
+        this.queryGateway = queryGateway;
+    }
+
+    /**
+     * Simple creation of a random new order.
+     */
+    @GetMapping(value = "/orders/new-random")
+    public CreateOrderCommand createRandomOrder() {
+        // 1. Generate somewhere between 1 to 3 random order items.
+        ArrayList<OrderItem> orderItems = IntStream.range(1, 4)
+                .mapToObj(i -> randomOrderItem())
+                .collect(Collectors.toCollection(ArrayList::new));
+        log.info("Created {} new random order items: {}", orderItems.size(), orderItems);
+
+        // 2. Create the command and issue it.
+        CreateOrderCommand createOrderCommand = new CreateOrderCommand(RandomStringUtils.randomAlphabetic(8), orderItems);
+        log.info("Issuing command: {}", createOrderCommand);
+        commandGateway.sendAndWait(createOrderCommand);
+
+        // 3. Return the command that was used to create the order
+        return createOrderCommand;
+    }
+
+    /**
+     * End to end scenario of:
+     * 1. (OrderCreated)   creating an order
+     * 2. (OrderCancelled) cancelling that order
+     */
+    @GetMapping(value = "/orders/cancel-scenario")
+    public String cancelOrderScenario() {
+        // 1. Create a new random order with given aggregate ID.
+        CreateOrderCommand randomOrder = createRandomOrder();
+        UUID aggregateId = UUID.fromString(randomOrder.getAggregateIdentifier());
+
+        // 2. Cancel the newly created order.
+        MarkOrderAsCancelledCommand cancelCmd = new MarkOrderAsCancelledCommand(aggregateId.toString());
+        commandGateway.sendAndWait(cancelCmd);
+
+        // 3. Return string back to caller.
+        return "OrderCancelled scenario complete";
+    }
+
+
+    /**
+     * End to end scenario of:
+     * 1. (OrderCreated)   creating an order
+     * 2. (OrderPaid)      paying for the order
+     * 3. (OrderCancelled) cancelling that order (will intentionally fail for this scenario)
+     */
+    @GetMapping(value = "/orders/cancel-after-paying-scenario-with-intentional-failure")
+    public void cancelOrderAfterPayingScenarioWithFailure() {
+        // 1. Create a new random order with given aggregate ID.
+        CreateOrderCommand randomOrder = createRandomOrder();
+        UUID aggregateId = UUID.fromString(randomOrder.getAggregateIdentifier());
+
+        // 2. Mark the order as paid.
+        MarkOrderAsPaidCommand cmd = new MarkOrderAsPaidCommand(aggregateId.toString());
+        log.info("Issuing command: {}", cmd);
+        commandGateway.sendAndWait(cmd);
+
+        // 3. Cancel the paid order with incorrect aggregateId.
+        // N.B. since we are using the aggregate identifier of the CreateOrderCommand we will get:
+        //      `CommandExecutionException(Aggregate with identifier [<some-uuid>] not found.
+        //       It has been deleted.` If we wanted this to succeed we would need to use the aggregate
+        //       identifier of the OrderPaid aggregate.
+        MarkOrderAsCancelledCommand cancelCmd = new MarkOrderAsCancelledCommand(aggregateId.toString());
+        commandGateway.send(cancelCmd);
+    }
+
+    /**
+     * End to end scenario of:
+     * 1. (OrderCreated)   creating an order
+     * 2. (OrderPaid)      paying for the order
+     * 3. (OrderCancelled) cancelling that order
+     */
+    @GetMapping(value = "/orders/cancel-after-paying-scenario")
+    public String cancelOrderAfterPayingScenarioWithSuccess() throws ExecutionException, InterruptedException {
+        // 1. Create a new random order with given aggregate ID.
+        CreateOrderCommand randomOrder = createRandomOrder();
+        String orderId = randomOrder.getOrderId();
+        UUID aggregateId = UUID.fromString(randomOrder.getAggregateIdentifier());
+
+        // 2. Mark the order as paid.
+        MarkOrderAsPaidCommand cmd = new MarkOrderAsPaidCommand(aggregateId.toString());
+        log.info("Issuing command: {}", cmd);
+        commandGateway.sendAndWait(cmd);
+
+        // Wait a second for the projection(s) to be processed.
+        Thread.sleep(1_000);
+
+        // Retrieve the latest IDs associated with each state for the orderId.
+        ConcurrentHashMap<OrderStatus, UUID> stateToAggregateIdMap = queryForStateToAggregateIdMap(orderId);
+
+        // 3. Cancel the paid order with the aggregateId of the PAID state (throwing NPE if no PAID state found).
+        UUID paidStateAggregateId = stateToAggregateIdMap.get(OrderStatus.PAID);
+        MarkOrderAsCancelledCommand cancelCmd = new MarkOrderAsCancelledCommand(paidStateAggregateId.toString());
+        commandGateway.send(cancelCmd);
+
+        // Return string back to caller.
+        return "cancel after paying scenario complete";
+    }
+
+    /**
+     * End to end scenario of:
+     * 1. (OrderCreated)   creating an order
+     * 2. (OrderPaid)      paying for the order
+     * 3. (OrderDelivered) the order is delivered
+     */
+    @GetMapping(value = "/orders/order-delivered-scenario")
+    public String orderDeliveredScenario() throws ExecutionException, InterruptedException {
+        // 1. Create a new random order with given aggregate ID.
+        CreateOrderCommand randomOrder = createRandomOrder();
+        String orderId = randomOrder.getOrderId();
+        UUID aggregateId = UUID.fromString(randomOrder.getAggregateIdentifier());
+
+        // 2. Mark the order as paid.
+        MarkOrderAsPaidCommand cmd = new MarkOrderAsPaidCommand(aggregateId.toString());
+        log.info("Issuing command: {}", cmd);
+        commandGateway.sendAndWait(cmd);
+
+        // Wait a second for the projection(s) to be processed.
+        Thread.sleep(1_000);
+
+        // Retrieve the latest IDs associated with each state for the orderId.
+        ConcurrentHashMap<OrderStatus, UUID> stateToAggregateIdMap = queryForStateToAggregateIdMap(orderId);
+
+        // 3. Deliver the order with the aggregateId of the PAID state.
+        UUID paidStateAggregateId = stateToAggregateIdMap.get(OrderStatus.PAID);
+        MarkOrderAsDeliveredCommand deliveredCommand = new MarkOrderAsDeliveredCommand(paidStateAggregateId.toString());
+        commandGateway.send(deliveredCommand);
+
+        return "order delivered scenario complete";
+    }
+
+    /* ***********************************************
+     * Utility Methods
+     * ***********************************************/
+    private OrderItem randomOrderItem() {
+        return OrderItem.builder()
+                // Use a unique long ID for convenience.
+                .id(String.valueOf(idGenerator.incrementAndGet()))
+                // Name of the order item is just a random alphabetical string of 8 characters.
+                .name(RandomStringUtils.randomAlphabetic(8))
+                // Price is a random value between 0.01 and 100.
+                .price(BigDecimal.valueOf(RandomUtils.nextDouble(0.01d, 100d)))
+                // Quantity is random value between 1 and 5.
+                .quantity(RandomUtils.nextLong(1, 6))
+                .build();
+    }
+
+    private ConcurrentHashMap<OrderStatus, UUID> queryForStateToAggregateIdMap(String orderId) throws ExecutionException, InterruptedException {
+        log.debug("Issuing query to retrieve all aggregate states for orderId: {}", orderId);
+        GetAllStateTransitionAggregateIdsRequest query = new GetAllStateTransitionAggregateIdsRequest(orderId);
+        GetAllStateTransitionAggregateIdsResponse resp = queryGateway
+                .query(query, ResponseTypes.instanceOf(GetAllStateTransitionAggregateIdsResponse.class)).get();
+        ConcurrentHashMap<OrderStatus, UUID> stateToAggregateId = resp.getStateToAggregateId();
+        log.debug("Retrieved all aggregate states for orderId: {}, statesToAggregateId: {}", orderId, stateToAggregateId);
+        return stateToAggregateId;
+    }
+
+}


### PR DESCRIPTION
This pull request has 4 commits. If you go through the file changes per commit then the changes are easy to understand:

1. Simply adds `@ToString` to the commands and events (for convenience when logging them).
2.  Adds dependency on apache commons lang (for convenience in generating random alphabetical strings)
3.  Adds a projection and query handler
4.  Adds a controller with end-to-end (e2e) scenarios defined as endpoints.

The main bulk is in pull requests (3) and (4). I figured people who come across this repo would find them useful. This way they can hit a single endpoint and have a whole e2e scenario run and inspect their Axon Server UI to see what events were stored (rather than having to make many post requests). 

Regards,
vab2048

